### PR TITLE
Add descriptions for 3 tests lacking them

### DIFF
--- a/t/Installed.t
+++ b/t/Installed.t
@@ -92,11 +92,13 @@ END { ok(chdir $startdir, "Return to where we started"); }
     my $fakepath = File::Spec->catdir('auto', $fakedir);
     ok( mkpath($fakepath), "Able to create directory $fakepath for testing" );
 
-    ok(open(PACKLIST, '>', File::Spec->catfile($fakepath, '.packlist')));
+    ok(open(PACKLIST, '>', File::Spec->catfile($fakepath, '.packlist')),
+        "Able to open .packlist for writing");
     print PACKLIST 'list';
     close PACKLIST;
 
-    ok(open(FAKEMOD, '>', File::Spec->catfile($fakepath, 'FakeMod.pm')));
+    ok(open(FAKEMOD, '>', File::Spec->catfile($fakepath, 'FakeMod.pm')),
+        "Able to open FakeMod.pm for writing");
 
     print FAKEMOD <<'FAKE';
 package FakeMod;


### PR DESCRIPTION
The lack of descriptions for three unit tests was noticed while studying
https://rt.cpan.org/Ticket/Display.html?id=130120.