### PR TITLE
Avoid un-necessary calls to `cwd()`, use `File::Spec->catfile(..)` instead.

### DIFF
--- a/lib/ExtUtils/Install.pm
+++ b/lib/ExtUtils/Install.pm
@@ -750,7 +750,8 @@ sub install { #XXX OS-SPECIFIC
             }
             # we have to do this for back compat with old File::Finds
             # and because the target is relative
-            my $save_cwd = _chdir($cwd);
+            my $save_cwd = File::Spec->catfile($cwd, $sourcedir);
+            _chdir($cwd);
             my $diff = $always_copy || _compare($sourcefile, $targetfile);
             $check_dirs{$targetdir}++
                 unless -w $targetfile;


### PR DESCRIPTION
While `File::Find` will `chdir()` to various directories while
traversing the list of files to install, we don't need to call `cwd()`
for each file; we already know "what directory we started in" along with
"what directory did `File::File` `chdir()` into", which we can combine
to get "the current directory".

While for most installs this is not of much significance, `Paws`
contains over 20,000 `.pm` files needing to be installed and this patch
allows us to eliminate 20,000 calls to `cwd()`, making the install
notably faster.

Locally, this takes `./Build install` down for me from ~13s to ~0.8s.