### PR TITLE
Respect INSTALL_QUIET for filters

### DIFF
--- a/lib/ExtUtils/Install.pm
+++ b/lib/ExtUtils/Install.pm
@@ -1191,7 +1191,7 @@ sub pm_to_blib {
         }
         if ($need_filtering) {
             run_filter($pm_filter, $from, $to);
-            print "$pm_filter <$from >$to\n";
+            print "$pm_filter <$from >$to\n" unless $INSTALL_QUIET;
         } else {
             _copy( $from, $to );
             print "cp $from $to\n" unless $INSTALL_QUIET;


### PR DESCRIPTION
The spew from filtering is annoying when trying to navigate errors
e.g. with vim's quickfix; it would be nice to have a way to quell it.
