### PR TITLE
avoid warnings under -w when checking for relocatable paths

### DIFF
--- a/lib/ExtUtils/Packlist.pm
+++ b/lib/ExtUtils/Packlist.pm
@@ -46,6 +46,7 @@ sub __find_relocations
     while (my ($raw_key, $raw_val) = each %Config) {
 	my $exp_key = $raw_key . "exp";
 	next unless exists $Config{$exp_key};
+	next unless defined $raw_val;
 	next unless $raw_val =~ m!\.\.\./!;
 	$paths{$Config{$exp_key}}++;
     }


### PR DESCRIPTION
It is possible for exp keys in Config to be undef, and when running under -w it would produce warnings when regexing that undef.